### PR TITLE
Workaround to avoid compilation/elaboration error with Cadence Xcelium

### DIFF
--- a/env/fabric/top.sv
+++ b/env/fabric/top.sv
@@ -61,11 +61,11 @@ module top();
       .PORT_TYPE      (TNOC_LOCAL_PORT  ),
       .MONITOR_MODE   (0                )
     ) u_connector_bfm_to_dut (
-      .types    (types                                       ),
-      .i_clk    (clk                                         ),
-      .i_rst_n  (rst_n                                       ),
-      .dut_if   (flit_if_b2d[i]                              ),
-      .bfm_if   (bfm_flit_if_b2d[CHANNELS*i:CHANNELS*(i+1)-1])
+      .types    (types                                        ),
+      .i_clk    (clk                                          ),
+      .i_rst_n  (rst_n                                        ),
+      .dut_if   (flit_if_b2d[i]                               ),
+      .bfm_if   (bfm_flit_if_b2d[CHANNELS*i:CHANNELS*(i+1)-1] )
     );
 
     tnoc_bfm_flit_if_connector #(
@@ -73,11 +73,11 @@ module top();
       .PORT_TYPE      (TNOC_LOCAL_PORT  ),
       .MONITOR_MODE   (1                )
     ) u_connector_dut_to_bfm (
-      .types    (types                                       ),
-      .i_clk    (clk                                         ),
-      .i_rst_n  (rst_n                                       ),
-      .dut_if   (flit_if_d2b[i]                              ),
-      .bfm_if   (bfm_flit_if_d2b[CHANNELS*i:CHANNELS*(i+1)-1])
+      .types    (types                                        ),
+      .i_clk    (clk                                          ),
+      .i_rst_n  (rst_n                                        ),
+      .dut_if   (flit_if_d2b[i]                               ),
+      .bfm_if   (bfm_flit_if_d2b[CHANNELS*i:CHANNELS*(i+1)-1] )
     );
   end
 

--- a/env/fabric/top.sv
+++ b/env/fabric/top.sv
@@ -61,11 +61,11 @@ module top();
       .PORT_TYPE      (TNOC_LOCAL_PORT  ),
       .MONITOR_MODE   (0                )
     ) u_connector_bfm_to_dut (
-      .types    (types                                                  ),
-      .i_clk    (clk                                                    ),
-      .i_rst_n  (rst_n                                                  ),
-      .dut_if   (flit_if_b2d[i]                                         ),
-      .bfm_if   (bfm_flit_if_b2d[CHANNELS*i:CHANNELS*(i+1)-1].initiator )
+      .types    (types                                       ),
+      .i_clk    (clk                                         ),
+      .i_rst_n  (rst_n                                       ),
+      .dut_if   (flit_if_b2d[i]                              ),
+      .bfm_if   (bfm_flit_if_b2d[CHANNELS*i:CHANNELS*(i+1)-1])
     );
 
     tnoc_bfm_flit_if_connector #(
@@ -73,11 +73,11 @@ module top();
       .PORT_TYPE      (TNOC_LOCAL_PORT  ),
       .MONITOR_MODE   (1                )
     ) u_connector_dut_to_bfm (
-      .types    (types                                                ),
-      .i_clk    (clk                                                  ),
-      .i_rst_n  (rst_n                                                ),
-      .dut_if   (flit_if_d2b[i]                                       ),
-      .bfm_if   (bfm_flit_if_d2b[CHANNELS*i:CHANNELS*(i+1)-1].monitor )
+      .types    (types                                       ),
+      .i_clk    (clk                                         ),
+      .i_rst_n  (rst_n                                       ),
+      .dut_if   (flit_if_d2b[i]                              ),
+      .bfm_if   (bfm_flit_if_d2b[CHANNELS*i:CHANNELS*(i+1)-1])
     );
   end
 

--- a/rtl/common/tnoc_packet_if.sv
+++ b/rtl/common/tnoc_packet_if.sv
@@ -42,7 +42,7 @@ interface tnoc_packet_if
   typedef types.tnoc_response_header        tnoc_response_header;
   typedef types.tnoc_packed_header          tnoc_packed_header;
 
-  function automatic logic [get_header_width(PACKET_CONFIG)-1:0] pack_header();
+  function automatic tnoc_packed_header pack_header();
     tnoc_common_header_fields common_fields;
 
     common_fields.packet_type         = header.packet_type;
@@ -112,7 +112,7 @@ interface tnoc_packet_if
   typedef types.tnoc_response_payload   tnoc_response_payload;
   typedef types.tnoc_packed_payload     tnoc_packed_payload;
 
-  function automatic logic [get_payload_width(PACKET_CONFIG)-1:0] pack_payload(tnoc_packet_type packet_type);
+  function automatic tnoc_packed_payload pack_payload(tnoc_packet_type packet_type);
     if (packet_type[TNOC_PACKET_TYPE_RESPONSE_BIT]) begin
       tnoc_response_payload response_payload;
       response_payload.data             = payload.data;

--- a/rtl/common/tnoc_packet_if.sv
+++ b/rtl/common/tnoc_packet_if.sv
@@ -42,7 +42,7 @@ interface tnoc_packet_if
   typedef types.tnoc_response_header        tnoc_response_header;
   typedef types.tnoc_packed_header          tnoc_packed_header;
 
-  function automatic tnoc_packed_header pack_header();
+  function automatic logic [tnoc_pkg::get_header_width(PACKET_CONFIG)-1:0] pack_header();
     tnoc_common_header_fields common_fields;
 
     common_fields.packet_type         = header.packet_type;
@@ -112,7 +112,7 @@ interface tnoc_packet_if
   typedef types.tnoc_response_payload   tnoc_response_payload;
   typedef types.tnoc_packed_payload     tnoc_packed_payload;
 
-  function automatic tnoc_packed_payload pack_payload(tnoc_packet_type packet_type);
+  function automatic logic [tnoc_pkg::get_payload_width(PACKET_CONFIG)-1:0] pack_payload(tnoc_packet_type packet_type);
     if (packet_type[TNOC_PACKET_TYPE_RESPONSE_BIT]) begin
       tnoc_response_payload response_payload;
       response_payload.data             = payload.data;


### PR DESCRIPTION
@taichi-ishitani The 1st change on `env/fabric/top.sv` is not so good because it means we cannot use modport with multiple interface instances but I heard this is the only solution to elaborate this kind of code with Xcelium.
The 2nd change on `rtl/common/tnoc_packet_if.sv` is what you wanted to do here but you didn't do so. I think it may cause some problem with Synopsys VCS. I'd like to hear your opinion on this.